### PR TITLE
Yaml code field instead of long text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ tags
 invoice2erpnext/docs/current
 node_modules/
 __init__.py
+.aider*

--- a/invoice2erpnext/invoice2erpnext/doctype/invoice_template/invoice_template.json
+++ b/invoice2erpnext/invoice2erpnext/doctype/invoice_template/invoice_template.json
@@ -30,7 +30,7 @@
  "fields": [
   {
    "fieldname": "yml",
-   "fieldtype": "Long Text",
+   "fieldtype": "Code",
    "label": "Yml",
    "reqd": 1
   },


### PR DESCRIPTION
The YAML field in the template editor is a long text field which looks confusing and lacks some convenience features. Changing the fieldtype to "Code" makes it more apparent that the block contains code. Also, it better shows the indentation etc. which is crucial when hand-editing YAML