### PR TITLE
fix: revert frappe dependency range to support versions 15.0.0 to <17…

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,4 +23,4 @@ version = { attr = "invoice2erpnext.__version__" }
 dependencies = { file = ["requirements.txt"] }
 
 [tool.bench.frappe-dependencies]
-frappe = ">=16.0.0,<17.0.0"
+frappe = ">=15.0.0,<17.0.0"


### PR DESCRIPTION
….0.0